### PR TITLE
loop-return-user-groups-Final

### DIFF
--- a/loopreturnusergroupsFINAL.sh
+++ b/loopreturnusergroupsFINAL.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+while IFS='' read -r line || [[ -n "$line" ]]; do
+    echo -n "$line "
+    aws iam list-groups-for-user --user-name $line --output text | cut -f 5 | (tr '\n' ' ' )
+    printf '\n'
+done < "usersforloop.txt"
+
+printf '\n'
+echo "these are all the groups for each user =)"
+printf '\n'
+#done


### PR DESCRIPTION
bash loop to pull users and their group memberships from AWS. uses 'cut' utility to return desired fields and prints them on single line